### PR TITLE
use fixed-width font for script display/edit

### DIFF
--- a/src/main/resources/hudson/plugins/python/Python/config.jelly
+++ b/src/main/resources/hudson/plugins/python/Python/config.jelly
@@ -2,6 +2,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%Script}" field="command" description="${%blurb(rootURL)}">
-        <f:textarea />
+        <f:textarea class="fixed-width" />
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
fixed-width font (mono space) is used for the *nix and Windows scripting built-in plugins for Jenkins as well as being more popular for coding overall
