### PR TITLE
Pipeline step implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.settings/
+work/
+.project
+.classpath
+target/
+inject-tests/
+test-output
+*~
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.565.1</version>
+        <version>1.580.1</version>
       <relativePath />
     </parent>
 
@@ -41,5 +41,12 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.4</version>
+        </dependency>
+    </dependencies>
 </project>  
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,12 @@
             <email>tyler@slide.com</email>
             <timezone>-8</timezone>
         </developer>
+        <developer>
+            <id>mazimkhan</id>
+            <name>Mohammad Azim Khan</name>
+            <email>mohammadazim@gmail.com</email>
+            <timezone>+0</timezone>
+        </developer>
     </developers>
 
   <scm>

--- a/src/main/java/hudson/plugins/python/pipeline/PythonExecution.java
+++ b/src/main/java/hudson/plugins/python/pipeline/PythonExecution.java
@@ -1,0 +1,54 @@
+package hudson.plugins.python.pipeline;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.inject.Inject;
+import hudson.AbortException;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.ListView;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.remoting.Channel;
+import hudson.tasks.CommandInterpreter;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+
+import java.util.ArrayList;
+
+/**
+ * Created by azikha01 on 14/10/2016.
+ */
+public class PythonExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+
+    @Inject
+    private transient PythonStep config;
+
+    @StepContextParameter
+    private transient Launcher launcher;
+
+    @StepContextParameter
+    private transient TaskListener listener;
+
+    @StepContextParameter
+    private transient FilePath ws;
+
+    @StepContextParameter
+    private transient Run<?,?> build;
+
+    @Override
+    protected Void run() throws Exception {
+        FilePath script = ws.createTextTempFile("hudson", ".py", config.getCommand(), false);
+        try {
+            ArrayList<String> cmd = new ArrayList<String>();
+            cmd.add("python");
+            cmd.add(script.getRemote());
+            int result = launcher.launch().cmds(cmd).envs(build.getEnvironment(listener)).stdout(listener).pwd(ws).join();
+            if (result != 0){
+                throw new AbortException("Python script exited with error code: " + result);
+            }
+        } finally {
+            script.delete();
+        }
+        return null;
+    }
+}

--- a/src/main/java/hudson/plugins/python/pipeline/PythonStep.java
+++ b/src/main/java/hudson/plugins/python/pipeline/PythonStep.java
@@ -1,0 +1,43 @@
+package hudson.plugins.python.pipeline;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.Serializable;
+
+/**
+ * Created by azikha01 on 14/10/2016.
+ */
+public class PythonStep extends AbstractStepImpl implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /* --- Step Properties --- */
+    /**
+     * Script in form of string.
+     */
+    @DataBoundSetter
+    private String command = null;
+
+    @DataBoundConstructor
+    public PythonStep(){}
+
+    public String getCommand(){ return command; }
+
+    @Extension
+    public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+        public static final String STEP_NAME = "py";
+
+        public DescriptorImpl(){
+            super(PythonExecution.class);
+        }
+
+        @Override
+        public String getFunctionName(){ return STEP_NAME; }
+
+        @Override
+        public String getDisplayName() { return STEP_NAME; }
+    }
+}

--- a/src/main/resources/hudson/plugins/python/pipeline/Messages.properties
+++ b/src/main/resources/hudson/plugins/python/pipeline/Messages.properties
@@ -1,0 +1,1 @@
+Python.DisplayName=Execute Python script

--- a/src/main/resources/hudson/plugins/python/pipeline/PythonStep/config.jelly
+++ b/src/main/resources/hudson/plugins/python/pipeline/PythonStep/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="${%Script}" field="command" description="${%blurb(rootURL)}">
+        <f:textarea class="codemirror fixed-width" codemirror-config="mode: 'text/x-python'"
+                    codemirror-mode="python" />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/python/pipeline/PythonStep/config.properties
+++ b/src/main/resources/hudson/plugins/python/pipeline/PythonStep/config.properties
@@ -1,0 +1,1 @@
+blurb=See <a href="{0}/env-vars.html" target=_new>the list of available environment variables</a>

--- a/src/main/resources/hudson/plugins/python/pipeline/PythonStep/help.html
+++ b/src/main/resources/hudson/plugins/python/pipeline/PythonStep/help.html
@@ -1,0 +1,6 @@
+<div>
+    <p>
+        Runs a Python script (defaults to <tt>python</tt> interpreter) for building the project.
+        The script will be run with the workspace as the current directory.
+    </p>
+</div>

--- a/src/main/resources/hudson/plugins/python/pipeline/PythonStep/index.jelly
+++ b/src/main/resources/hudson/plugins/python/pipeline/PythonStep/index.jelly
@@ -1,0 +1,3 @@
+<div>
+    This is Python plugin. The build scripts written in python will be executed by this plugin.
+</div>

--- a/src/main/resources/hudson/plugins/python/pipeline/PythonStep/index.jelly
+++ b/src/main/resources/hudson/plugins/python/pipeline/PythonStep/index.jelly
@@ -1,3 +1,3 @@
 <div>
-    This is Python plugin. The build scripts written in python will be executed by this plugin.
+    This is the Python plugin. The build scripts written in Python will be executed by this plugin.
 </div>


### PR DESCRIPTION
Now python script step can be used in pipeline jobs as:

```
py command: "print '${BUILD_NUMBER}'"
```

Created corresponding Jira issue: JENKINS-39045 https://issues.jenkins-ci.org/browse/JENKINS-39045
